### PR TITLE
Add default mediatorUrl logic to loadOnce().

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ export async function loadOnce(mediatorUrl) {
   }
 
   if(!mediatorUrl) {
-    if (typeof window === 'undefined') {
+    if(typeof window === 'undefined') {
       throw new Error(
         'mediatorUrl is required, cannot use default URL with location.origin');
     }

--- a/index.js
+++ b/index.js
@@ -15,33 +15,20 @@ import {CredentialsContainer} from './CredentialsContainer.js';
 import {PermissionManager} from './PermissionManager.js';
 import {WebCredential} from './WebCredential.js';
 
-const DEFAULT_MEDIATOR = 'https://beta.authn.io/mediator';
+const DEFAULT_MEDIATOR = 'https://authn.io/mediator' + '?origin=' +
+  encodeURIComponent(window.location.origin);
 
 let loaded;
-export async function loadOnce(mediatorUrl) {
+export async function loadOnce(mediatorUrl = DEFAULT_MEDIATOR) {
   if(loaded) {
     return loaded;
-  }
-
-  if(!mediatorUrl) {
-    if(typeof window === 'undefined') {
-      throw new Error(
-        '"mediatorUrl" is required; cannot use default URL with "location.origin".');
-    }
-    mediatorUrl = DEFAULT_MEDIATOR + '?origin=' +
-      encodeURIComponent(window.location.origin);
   }
 
   loaded = true;
   return load(mediatorUrl);
 }
 
-export async function load(mediatorUrl) {
-  if(!mediatorUrl) {
-    mediatorUrl = 'https://credential.mediator.dev:15443/mediator?origin=' +
-      encodeURIComponent(window.location.origin);
-  }
-
+export async function load(mediatorUrl = DEFAULT_MEDIATOR) {
   const appContext = new rpc.WebAppContext();
   const injector = appContext.createWindow(mediatorUrl, {
     className: 'credential-mediator',

--- a/index.js
+++ b/index.js
@@ -15,11 +15,23 @@ import {CredentialsContainer} from './CredentialsContainer.js';
 import {PermissionManager} from './PermissionManager.js';
 import {WebCredential} from './WebCredential.js';
 
+const DEFAULT_MEDIATOR = 'https://beta.authn.io/mediator';
+
 let loaded;
 export async function loadOnce(mediatorUrl) {
   if(loaded) {
     return loaded;
   }
+
+  if(!mediatorUrl) {
+    if (typeof window === 'undefined') {
+      throw new Error(
+        'mediatorUrl is required, cannot use default URL with location.origin');
+    }
+    mediatorUrl = DEFAULT_MEDIATOR + '?origin=' +
+      encodeURIComponent(window.location.origin);
+  }
+
   loaded = true;
   return load(mediatorUrl);
 }

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ export async function loadOnce(mediatorUrl) {
   if(!mediatorUrl) {
     if(typeof window === 'undefined') {
       throw new Error(
-        'mediatorUrl is required, cannot use default URL with location.origin');
+        '"mediatorUrl" is required; cannot use default URL with "location.origin".');
     }
     mediatorUrl = DEFAULT_MEDIATOR + '?origin=' +
       encodeURIComponent(window.location.origin);


### PR DESCRIPTION
This allows for client apps to just call `polyfill.loadOnce()`, and not be required to decide on a default mediator. (They still can use it as a parameter, to override, of course).