### PR TITLE
Do not throw when navigator.credentials cannot be redefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # credential-handler-polyfill ChangeLog
 
+## 4.0.2 - 2026-06-dd
+
+### Fixed
+- Do not throw during `load()` on browsers (e.g., WebKit/iOS) where
+  `navigator.credentials` cannot be redefined via `Object.defineProperty`;
+  fall back to plain assignment or, failing that, skip installing the
+  proxy that protects against subsequent overwrites.
+
 ## 4.0.1 - 2025-12-16
 
 ### Fixed

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2017-2024 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2017-2026 Digital Bazaar, Inc. All rights reserved.
  */
 /* global navigator, window */
 import {WebAppContext} from 'web-request-rpc';
@@ -104,10 +104,22 @@ export async function load(options = {
     }
   });
 
-  Object.defineProperty(navigator, 'credentials', {
-    value: navCredentialsProxy,
-    writable: true
-  });
+  try {
+    Object.defineProperty(navigator, 'credentials', {
+      value: navCredentialsProxy,
+      writable: true
+    });
+  } catch(e) {
+    // on WebKit, `navigator.credentials` is a non-configurable property
+    // that cannot be redefined as a data property; fall back to plain
+    // assignment and, if that also fails, continue without the proxy --
+    // `get` and `store` have already been replaced on the existing
+    // `navigator.credentials` above, so only the protection against
+    // subsequent overwrites of `navigator.credentials` itself is lost
+    try {
+      navigator.credentials = navCredentialsProxy;
+    } catch(e2) {}
+  }
 
   window.CredentialManager = CredentialManager;
   window.WebCredential = WebCredential;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2017-2026 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2017-2026 Digital Bazaar, Inc.
  */
 /* global navigator, window */
 import {WebAppContext} from 'web-request-rpc';


### PR DESCRIPTION
Fixes #51.

On WebKit (all iOS browsers, desktop Safari), `navigator.credentials` is a non-configurable property, so the `Object.defineProperty()` call used since 3.2.1 to install the anti-clobber proxy throws a `TypeError`, causing `load()`/`loadOnce()` to reject and CHAPI to never initialize.

### Changes

- Wrap the `defineProperty()` call in a try/catch.
- On failure, fall back to plain assignment of the proxy.
- If assignment also fails (WebKit can expose the property as getter-only, which throws on assignment in strict mode), continue without the proxy. This is safe because `get` and `store` have already been replaced directly on the existing `navigator.credentials` object earlier in `load()` — only the protection against subsequent overwrites of the property itself is lost, matching the pre-3.2.1 behavior that works on iOS.
- Add changelog entry for 4.0.2.

### Testing

- `npm run lint` passes; webpack build compiles.
- Verified manually in Safari (WebKit) with a local test page: before the fix, `loadOnce()` rejects with `TypeError: Attempting to change writable attribute of unconfigurable property`; with the fix, `loadOnce()` resolves, `window.WebCredential` is defined, and `navigator.credentials.get/store` are patched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)